### PR TITLE
Adds local react import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formik-schema",
-  "version": "1.0.4-alpha",
+  "version": "1.0.5",
   "description": "Generate Bootstrap forms using JSON schemas and Formik",
   "main": "lib/formik-schema.js",
   "scripts": {

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -1,9 +1,10 @@
+import React from 'react';
 import { Formik } from 'formik';
 
 import { buildRenderFunction } from './registry';
 
 export class Form extends React.Component {
-  render () {
+  render() {
     return (
       <Formik
         {...this.props}


### PR DESCRIPTION
This adds a react import. Currently the library depends on a global react variable, and throws and error, if it's used with webpacks import.

